### PR TITLE
Wrong ownership for properties

### DIFF
--- a/reference/measures.csv-metadata.json
+++ b/reference/measures.csv-metadata.json
@@ -70,6 +70,6 @@
         ],
         "aboutUrl": "http://gss-data.org.uk/def/measure/{+path}"
     },
-    "rdfs:label": "GSS Measures",
-    "dc:title": "GSS Measures"
+    "rdfs:label": "GSS Common Measures",
+    "dc:title": "GSS Common Measures"
 }

--- a/reference/properties.csv-metadata.json
+++ b/reference/properties.csv-metadata.json
@@ -5,9 +5,9 @@
             "@language": "en"
         }
     ],
-    "@id": "http://gss-data.org.uk/def/trade/ontology/properties",
+    "@id": "http://gss-data.org.uk/def/ontology/properties",
     "prov:hadDerivation": {
-        "@id": "http://gss-data.org.uk/def/trade/ontology/properties",
+        "@id": "http://gss-data.org.uk/def/ontology/properties",
         "@type": "owl:Ontology"
     },
     "url": "properties.csv",
@@ -72,6 +72,6 @@
         ],
         "aboutUrl": "http://gss-data.org.uk/def/property/{+path}"
     },
-    "rdfs:label": "GSS Trade Properties",
-    "dc:title": "GSS Trade Properties"
+    "rdfs:label": "GSS Common Properties",
+    "dc:title": "GSS Common Properties"
 }


### PR DESCRIPTION
Despite being empty, properties was in the wrong namespace.

Note: after merging, re-run the ref_common pipeline before the ref pipeline in trade.